### PR TITLE
Add temperature effect to battery drain

### DIFF
--- a/src/environment/lowpolydrone.ts
+++ b/src/environment/lowpolydrone.ts
@@ -48,6 +48,7 @@ export async function createLowpolydrone(level: Level): Promise<Drone> {
       .setFriction(0.5),
     droneBody,
   );
+  void _droneCol;
 
   level.scene.add(droneGroup);
 

--- a/src/environment/tu95.ts
+++ b/src/environment/tu95.ts
@@ -31,4 +31,5 @@ export async function createTU96(level: Level, pos: THREE.Vector3) {
   const _planeCol = level.world.createCollider(
     ColliderDesc.cuboid(5, 3, 10).setTranslation(pos.x, pos.y + 3, pos.z),
   );
+  void _planeCol;
 }

--- a/src/level/BasicLevel.ts
+++ b/src/level/BasicLevel.ts
@@ -442,7 +442,8 @@ export default class BasicLevel extends Level {
 
     if (this.temperatureChangeTimer >= this.temperatureChangeInterval) {
       // Generate new temperature target between 50°F and 90°F
-      this.targetTemperature = 50 + Math.random() * 20;
+      // 40 degree range
+      this.targetTemperature = 50 + Math.random() * 40;
       this.temperatureChangeTimer = 0;
     }
 
@@ -464,8 +465,14 @@ export default class BasicLevel extends Level {
 
   updateBattery(deltaTime: number): void {
     const throttleSquared = this.controls.throttle * this.controls.throttle;
-    const drainRate =
+    let drainRate =
       (100 / config.maxFlightTime) * (0.5 + throttleSquared * 1.5); // Base drain + throttle-based drain
+
+    // Increase drain in extreme temperatures
+    if (this.temperature < 60 || this.temperature > 80) {
+      drainRate *= 1.5;
+    }
+
     this.batteryLevel = Math.max(0, this.batteryLevel - drainRate * deltaTime);
   }
 


### PR DESCRIPTION
## Summary
- fix unused collider warnings so `npm run build` succeeds
- widen the temperature range and use the value when draining the battery

## Testing
- `npx tsc -p tsconfig.json`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_683f12b65ee883229d42f494c7391202