### PR TITLE
Add checkpoint system

### DIFF
--- a/src/environment/checkpoint.ts
+++ b/src/environment/checkpoint.ts
@@ -1,0 +1,30 @@
+import RAPIER, { ColliderDesc } from "@dimforge/rapier3d-compat";
+import * as THREE from "three";
+import type Level from "../level/Level";
+
+export type Checkpoint = {
+  mesh: THREE.Mesh;
+  collider: RAPIER.Collider;
+  done: boolean;
+};
+
+export function createCheckpoint(
+  level: Level,
+  position: THREE.Vector3,
+  radius = 0.25,
+): Checkpoint {
+  const geometry = new THREE.SphereGeometry(radius, 16, 16);
+  const material = new THREE.MeshStandardMaterial({ color: 0xff0000 });
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.castShadow = true;
+  mesh.position.copy(position);
+  level.scene.add(mesh);
+
+  const collider = level.world.createCollider(
+    ColliderDesc.ball(radius)
+      .setTranslation(position.x, position.y, position.z)
+      .setSensor(true),
+  );
+
+  return { mesh, collider, done: false };
+}

--- a/src/environment/lowpolydrone.ts
+++ b/src/environment/lowpolydrone.ts
@@ -41,14 +41,13 @@ export async function createLowpolydrone(level: Level): Promise<Drone> {
       .setCcdEnabled(true),
   );
 
-  const _droneCol = level.world.createCollider(
+  const droneCol = level.world.createCollider(
     RAPIER.ColliderDesc.cuboid(0.52, 0.075, 0.52)
       .setMass(config.droneMass)
       .setRestitution(0.2)
       .setFriction(0.5),
     droneBody,
   );
-  void _droneCol;
 
   level.scene.add(droneGroup);
 
@@ -56,5 +55,6 @@ export async function createLowpolydrone(level: Level): Promise<Drone> {
     body: droneBody,
     group: droneGroup,
     propellers: propellers,
+    collider: droneCol,
   };
 }

--- a/src/level/BasicLevel.ts
+++ b/src/level/BasicLevel.ts
@@ -3,6 +3,7 @@ import * as THREE from "three";
 import * as config from "../config";
 import { createLowpolydrone } from "../environment/lowpolydrone";
 import { createTU96 } from "../environment/tu95";
+import { createCheckpoint, type Checkpoint } from "../environment/checkpoint";
 import Level from "./Level";
 
 export default class BasicLevel extends Level {
@@ -36,6 +37,8 @@ export default class BasicLevel extends Level {
   environmentTemperatureChangeInterval: number;
 
   motorSpeeds: number[] = [0, 0, 0, 0];
+
+  checkpoints: Checkpoint[] = [];
 
   // Settings
   settings = {
@@ -111,6 +114,10 @@ export default class BasicLevel extends Level {
     this.createLighting();
     this.createFloor();
     this.createSkybox();
+
+    // Example checkpoint
+    const cp = createCheckpoint(this, new THREE.Vector3(2, 1, -2));
+    this.checkpoints.push(cp);
   }
 
   createSkybox() {
@@ -218,6 +225,7 @@ export default class BasicLevel extends Level {
     this.updatePing(deltaTime);
     this.updateBattery(deltaTime);
     this.updatePhysics(deltaTime);
+    this.updateCheckpoints();
     this.updateGraphics(deltaTime);
     this.updateHUD(deltaTime);
   }
@@ -534,6 +542,15 @@ export default class BasicLevel extends Level {
     }
 
     this.batteryLevel = Math.max(0, this.batteryLevel - drainRate * deltaTime);
+  }
+
+  updateCheckpoints(): void {
+    for (const cp of this.checkpoints) {
+      if (!cp.done && this.world.intersectionPair(this.drone!.collider, cp.collider)) {
+        cp.done = true;
+        (cp.mesh.material as THREE.MeshStandardMaterial).color.set(0x00ff00);
+      }
+    }
   }
 
   updateHUD(_deltaTime: number) {

--- a/src/level/Level.ts
+++ b/src/level/Level.ts
@@ -13,6 +13,7 @@ export type Drone = {
   body: RAPIER.RigidBody;
   group: THREE.Group;
   propellers: THREE.Object3D[];
+  collider: RAPIER.Collider;
 };
 
 export default class Level {


### PR DESCRIPTION
## Summary
- add collider property to `Drone`
- support checkpoints with simple collider and color change on completion
- expose drone collider from `createLowpolydrone`
- create example checkpoint in `BasicLevel`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_683f2298be8c832291e68a2d3bd02b21